### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '1.22'
 
@@ -311,6 +314,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/SPANDigital/pg-cel/security/code-scanning/6](https://github.com/SPANDigital/pg-cel/security/code-scanning/6)

To resolve the issue, we will add a `permissions` block at the root level of the workflow. This will apply minimal permissions to all jobs unless overridden by a job-specific `permissions` block. The `release` job requires `contents: read` and `contents: write` to create a GitHub release and upload assets. Other jobs, such as `build-linux`, `build-macos`, and `test`, only require `contents: read` to download artifacts or access repository contents. 

- Modify the root of the workflow to include a `permissions` block with `contents: read` as the default.
- Add a job-specific `permissions` block to the `release` job to grant `contents: write` for creating releases.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
