### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]
@@ -98,6 +101,8 @@ jobs:
 
   test-macos:
     runs-on: macos-latest
+    permissions:
+      contents: read
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/SPANDigital/pg-cel/security/code-scanning/3](https://github.com/SPANDigital/pg-cel/security/code-scanning/3)

To resolve the issue, add an explicit `permissions` block to the root of the workflow or inside the `test-macos` job. The permissions should restrict access to the repository to `contents: read`, which is the least privilege required for most workflows and jobs unless additional access (e.g., `pull-requests: write`) is explicitly needed.

Changes to `.github/workflows/ci.yml`:
1. Add a `permissions` block at the root level, applying to all jobs unless overridden.
2. Alternatively, add a `permissions` block specifically under the `test-macos` job if other jobs require different permissions.

The explicit permissions block should look like:
```yaml
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
